### PR TITLE
Improve planner with multi-day events and modal creation

### DIFF
--- a/assets/css/planner.css
+++ b/assets/css/planner.css
@@ -2,12 +2,14 @@
   display: flex;
   flex-wrap: wrap;
   margin-bottom: 20px;
+  align-items: flex-start;
 }
 .planner .col {
   flex: 1;
   min-width: 300px;
   padding: 10px;
 }
+.month-view { position: relative; }
 .calendar-nav {
   display: flex;
   justify-content: center;
@@ -42,6 +44,50 @@
   border-radius: 50%;
   display: inline-block;
 }
+#unpaidInvoices { max-height: 300px; overflow: auto; }
+.notes, .unpaid { flex: 1 1 50%; }
+#notesList { max-height: 300px; overflow: auto; }
+.add-event-btn {
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  border: none;
+  background: #28a745;
+  color: #fff;
+  font-size: 24px;
+  line-height: 32px;
+  cursor: pointer;
+}
+.modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0,0,0,0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.modal.hidden { display: none; }
+.modal-content {
+  background: #fff;
+  padding: 20px;
+  border-radius: 4px;
+  position: relative;
+}
+.modal-content .close {
+  position: absolute;
+  right: 8px;
+  top: 8px;
+  background: none;
+  border: none;
+  font-size: 20px;
+  cursor: pointer;
+}
 #dayEvents .event {
   margin: 5px 0;
   padding: 4px;
@@ -49,21 +95,22 @@
   background: #f5f5f5;
   position: relative;
 }
-#dayEvents .event button {
-  position: absolute;
-  right: 4px;
-  top: 4px;
-}
-.notes ul { list-style: none; padding: 0; }
-.notes li {
-  margin: 4px 0;
-  padding: 4px 20px 4px 4px;
-  position: relative;
-}
+#dayEvents .event button,
 .notes li button {
   position: absolute;
   right: 4px;
   top: 4px;
+  width: 16px;
+  height: 16px;
+  padding: 0;
+  font-size: 12px;
+  line-height: 16px;
+}
+.notes ul { list-style: none; padding: 0; margin: 0; }
+.notes li {
+  margin: 4px 0;
+  padding: 4px 20px 4px 4px;
+  position: relative;
 }
 .unpaid table {
   width: 100%;

--- a/includes/process_planner.php
+++ b/includes/process_planner.php
@@ -29,16 +29,20 @@ function writej(string $file, array $data): bool {
 $action = $_POST['action'] ?? '';
 
 switch ($action) {
-  case 'addEvent': {
-    $date  = trim($_POST['date']  ?? '');
-    $title = trim($_POST['title'] ?? '');
-    if ($date === '' || $title === '') {
-      echo json_encode(['success'=>false,'error'=>'Trūkst datums vai nosaukums']);
-      break;
-    }
-    $start = trim($_POST['start'] ?? '');
-    $end   = trim($_POST['end']   ?? '');
-    $color = trim($_POST['color'] ?? '#000000');
+    case 'addEvent': {
+      $date  = trim($_POST['date']  ?? '');
+      $endDate = trim($_POST['end_date'] ?? '');
+      $title = trim($_POST['title'] ?? '');
+      if ($date === '' || $title === '') {
+        echo json_encode(['success'=>false,'error'=>'Trūkst datums vai nosaukums']);
+        break;
+      }
+      if ($endDate !== '' && $endDate < $date) {
+        $endDate = $date;
+      }
+      $start = trim($_POST['start'] ?? '');
+      $end   = trim($_POST['end']   ?? '');
+      $color = trim($_POST['color'] ?? '#000000');
     $events = readj($eventsFile);
     $id = 1;
     foreach ($events as $e) {
@@ -46,9 +50,10 @@ switch ($action) {
         $id = $e['id'] + 1;
       }
     }
-    $new = ['id'=>$id,'date'=>$date,'title'=>$title,'color'=>$color];
-    if ($start !== '') $new['start'] = $start;
-    if ($end !== '')   $new['end']   = $end;
+      $new = ['id'=>$id,'date'=>$date,'title'=>$title,'color'=>$color];
+      if ($endDate !== '') $new['end_date'] = $endDate;
+      if ($start !== '') $new['start'] = $start;
+      if ($end   !== '') $new['end']   = $end;
     $events[] = $new;
     writej($eventsFile, $events);
     echo json_encode(['success'=>true,'event'=>$new], JSON_UNESCAPED_UNICODE);

--- a/views/planner.php
+++ b/views/planner.php
@@ -32,21 +32,13 @@ if (is_dir($dataDir . 'archive')) {
 <div class="planner">
   <div class="row">
     <div class="col month-view">
+      <button id="addEventBtn" class="add-event-btn" type="button">+</button>
       <div class="calendar-nav">
         <button id="prevMonth" type="button">&lt;</button>
         <span id="monthLabel"></span>
         <button id="nextMonth" type="button">&gt;</button>
       </div>
       <div id="calendar"></div>
-      <form id="eventForm">
-        <h3>Pievienot notikumu</h3>
-        <label>Datums: <input type="date" name="date" required></label>
-        <label>Sākums: <input type="time" name="start"></label>
-        <label>Beigas: <input type="time" name="end"></label>
-        <label>Nosaukums: <input type="text" name="title" required></label>
-        <label>Krāsa: <input type="color" name="color" value="#0000ff"></label>
-        <button type="submit">Pievienot</button>
-      </form>
     </div>
     <div class="col day-view">
       <h3 id="dayLabel"></h3>
@@ -56,7 +48,7 @@ if (is_dir($dataDir . 'archive')) {
   <div class="row">
     <div class="col notes">
       <h3>Piezīmes</h3>
-      <form id="noteForm">
+      <form id="noteForm" accept-charset="UTF-8">
         <input type="text" id="noteText" name="text" placeholder="Piezīme" required>
         <input type="color" id="noteColor" name="color" value="#ffff88">
         <button type="submit">Pievienot</button>
@@ -82,6 +74,21 @@ if (is_dir($dataDir . 'archive')) {
         </tbody>
       </table>
     </div>
+  </div>
+</div>
+<div id="eventModal" class="modal hidden">
+  <div class="modal-content">
+    <button type="button" class="close">×</button>
+    <form id="eventForm" accept-charset="UTF-8">
+      <h3>Pievienot notikumu</h3>
+      <label>Sākuma datums: <input type="date" name="date" required></label>
+      <label>Beigu datums: <input type="date" name="end_date"></label>
+      <label>Sākums: <input type="time" name="start"></label>
+      <label>Beigas: <input type="time" name="end"></label>
+      <label>Nosaukums: <input type="text" name="title" required></label>
+      <label>Krāsa: <input type="color" name="color" value="#0000ff"></label>
+      <button type="submit">Pievienot</button>
+    </form>
   </div>
 </div>
 <script>


### PR DESCRIPTION
## Summary
- Add floating plus button that opens a modal to create events with optional end date
- Support multi-day events in planner front-end and back-end
- Make invoice table scrollable and enforce UTF-8 forms
- Prevent notes from overlapping invoices and shrink delete buttons with confirmations
- Show multi-day events as full-day on intermediate dates

## Testing
- `php -l views/planner.php`
- `php -l includes/process_planner.php`
- `node --check assets/js/planner.js && echo "JS OK"`


------
https://chatgpt.com/codex/tasks/task_e_68b085d520508332bc1b1f10ebea67e1