### PR TITLE
Improve planner layout and event actions

### DIFF
--- a/assets/css/planner.css
+++ b/assets/css/planner.css
@@ -87,26 +87,32 @@
 }
 #dayEvents .event {
   margin: 5px 0;
-  padding: 4px;
+  padding: 4px 24px 4px 4px;
   border-left: 6px solid;
   background: #f5f5f5;
   position: relative;
 }
+.notes ul { list-style: none; padding: 0; }
+.notes li {
+  margin: 4px 0;
+  padding: 4px 24px 4px 4px;
+  position: relative;
+  word-wrap: break-word;
+  overflow-wrap: anywhere;
+}
+.notes li button,
 #dayEvents .event button {
   position: absolute;
   right: 4px;
   top: 4px;
-}
-.notes ul { list-style: none; padding: 0; }
-.notes li {
-  margin: 4px 0;
-  padding: 4px 20px 4px 4px;
-  position: relative;
-}
-.notes li button {
-  position: absolute;
-  right: 4px;
-  top: 4px;
+  width: 20px;
+  height: 20px;
+  padding: 0;
+  border: none;
+  background: none;
+  font-size: 16px;
+  line-height: 20px;
+  cursor: pointer;
 }
 .unpaid table {
   width: 100%;

--- a/assets/js/planner.js
+++ b/assets/js/planner.js
@@ -60,7 +60,19 @@ function renderDay() {
     const div = document.createElement('div');
     div.className = 'event';
     div.style.borderColor = e.color;
-    const time = (e.start?e.start:'') + (e.end?'-'+e.end:'');
+    let time = '';
+    if (e.end_date && e.end_date !== e.date) {
+      if (dateStr > e.date && dateStr < e.end_date) {
+        time = 'Pilna diena';
+      } else if (dateStr === e.date && e.start) {
+        time = e.start;
+      } else if (dateStr === e.end_date && e.end) {
+        time = e.end;
+      }
+    } else {
+      if (e.start) time = e.start;
+      if (e.end) time = (time?time+'-':'') + e.end;
+    }
     const span = document.createElement('span');
     span.textContent = (time?`[${time}] `:'') + e.title;
     div.appendChild(span);
@@ -73,7 +85,8 @@ function renderDay() {
 }
 
 function deleteEvent(id){
-    fetch('includes/process_planner.php', {
+  if(!confirm('Vai tiešām dzēst šo notikumu?')) return;
+  fetch('includes/process_planner.php', {
     method: 'POST',
     body: new URLSearchParams({action:'deleteEvent', id})
   }).then(r=>r.json()).then(res=>{
@@ -130,6 +143,7 @@ function renderNotes(){
 }
 
 function deleteNote(id){
+  if(!confirm('Vai tiešām dzēst šo ierakstu?')) return;
   fetch('includes/process_planner.php', {
     method:'POST',
     body:new URLSearchParams({action:'deleteNote', id})


### PR DESCRIPTION
## Summary
- Prevent notes list from overlapping unpaid invoices by adding wrapping, padding, and compact delete buttons.
- Ask for confirmation before deleting events or notes.
- Display multi-day events with full-day midpoints and correct start/end times.

## Testing
- `node --check assets/js/planner.js`
- `php -l includes/process_planner.php`


------
https://chatgpt.com/codex/tasks/task_e_68b08cbf3b48833293d54e43e87c471b